### PR TITLE
reduce max-open-files for tikv & run prometheus as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ mysql -h 127.0.0.1 -P 4000 -u root
 * config/tikv.toml is copied from [TiKV repo](https://github.com/pingcap/tikv/tree/master/etc)
 * config/tidb.toml is copied from [TiDB repo](https://github.com/pingcap/tidb/tree/master/config)
 
-If you find these configuration files outdated or mismatch with TiDB version, you can copy these files from their upstream repos and change their metrics addr with `pushgateway:9091`
+If you find these configuration files outdated or mismatch with TiDB version, you can copy these files from their upstream repos and change their metrics addr with `pushgateway:9091`. Also `max-open-files` are configured to `1024` in tikv.toml to simplify quick start on Linux, because setting up ulimit on Linux with docker is quite tedious.
 
 And config/*-dashboard.json are copied from [TiDB-Ansible repo](https://github.com/pingcap/tidb-ansible/tree/master/scripts)
 

--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       - --initial-cluster={{- template "initial_cluster" $ }}
       - --data-dir=/data/pd{{ . }}
       - --config=/pd.toml
+    # sysctls:
+    #   net.core.somaxconn: 32768
+    # ulimits:
+    #   nofile:
+    #     soft: 1000000
+    #     hard: 1000000
     restart: on-failure
   {{- end }}
 
@@ -83,6 +89,12 @@ services:
       {{- range until $pdSize }}
       - "pd{{.}}"
       {{- end }}
+    # sysctls:
+    #   net.core.somaxconn: 32768
+    # ulimits:
+    #   nofile:
+    #     soft: 1000000
+    #     hard: 1000000
     restart: on-failure
   {{- end }}
 
@@ -125,6 +137,12 @@ services:
       {{- range until $tikvSize }}
       - "tikv{{.}}"
       {{- end }}
+    # sysctls:
+    #   net.core.somaxconn: 32768
+    # ulimits:
+    #   nofile:
+    #     soft: 1000000
+    #     hard: 1000000
     restart: on-failure
 
 {{- if .Values.tidbVision }}
@@ -163,6 +181,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     restart: on-failure
   prometheus:
+    user: root
     image: {{ $prometheusImage }}
     command:
       - --storage.tsdb.path=/data/prometheus

--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -166,7 +166,7 @@ address = "pushgateway:9091"
 # If max-open-files = -1, RocksDB will prefetch index and filter blocks into
 # block cache at startup, so if your database has a large working set, it will
 # take several minutes to open the db.
-# max-open-files = 40960
+max-open-files = 1024
 
 # Max size of rocksdb's MANIFEST file.
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/wiki/MANIFEST
@@ -380,7 +380,7 @@ address = "pushgateway:9091"
 
 [raftdb]
 # max-sub-compactions = 1
-# max-open-files = 40960
+max-open-files = 1024
 # max-manifest-file-size = "20MB"
 # create-if-missing = true
 # writable-file-max-buffer-size = "1MB"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     restart: on-failure
   prometheus:
+    user: root
     image: prom/prometheus:v2.0.0
     command:
       - --storage.tsdb.path=/data/prometheus


### PR DESCRIPTION
This PR fixes quick start ulimit and permission problems on Linux.
PTAL @datahoecn @c4pt0r @iamxy 