### PR TITLE
downgrade docker-compose file version to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TiDB docker-compose
 
+## Requirements
+
+* Docker >= 16.10
+* Docker Compose >= 1.6.0
+
 ## Quick start
 
 ```bash

--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -12,7 +12,7 @@
 {{- $prometheusPort := .Values.prometheus.port | default "9090" }}
 {{- $pushgatewayImage := .Values.pushgateway.image | default "prom/pushgateway:v0.3.1" }}
 {{- $dashboardInstallerImage := .Values.dashboardInstaller.image | default "pingcap/tidb-dashboard-installer:v1.0.0" }}
-version: '2.3'
+version: '2.1'
 
 services:
   {{- range until $pdSize }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.1'
 
 services:
   pd0:


### PR DESCRIPTION
This PR downgrades docker-compose file version according to [Docker Compose Documentation](https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix)
PTAL @onlymellb 