### PR TITLE
add tispark service and its Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Default user/password: admin/admin
 
 * Access [tidb-vision](https://github.com/pingcap/tidb-vision) at http://localhost:8010
 
+* Access Spark Web UI at http://localhost:8080
+  and access [TiSpark](https://github.com/pingcap/tispark) through spark://127.0.0.1:7077
 
 ## Customize TiDB Cluster
 
@@ -75,6 +77,8 @@ You can build docker image yourself for development test.
   *Note:* Compiling tikv from source consumes lots of memory, memory of Docker for Mac needs to be adjusted to greater than 6GB
 
 [tidb-vision](https://github.com/pingcap/tidb-vision) is a visiualization page of TiDB Cluster, it's WIP project and can be disabled by commenting `tidbVision` out.
+
+[TiSpark](https://github.com/pingcap/tispark) is a thin layer built for running Apache Spark on top of TiDB/TiKV to answer the complex OLAP queries.
 
 ### Debug TiDB/TiKV/PD instances
 Prerequisites:

--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -1,5 +1,6 @@
 {{- $pdSize := .Values.pd.size | int }}
 {{- $tikvSize := .Values.tikv.size | int }}
+{{- $tisparkWorkerCount := .Values.tispark.workerCount | int }}
 {{- define "initial_cluster" }}
 {{- range until (.Values.pd.size | int) }}{{if .}},{{end}}pd{{.}}=http://pd{{.}}:2380{{- end }}
 {{- end }}
@@ -118,6 +119,54 @@ services:
     #     hard: 1000000
     restart: on-failure
 
+{{- if .Values.tispark }}
+  tispark-master:
+    {{- if .Values.tispark.image }}
+    image: {{ .Values.tispark.image }}
+    {{- else }}
+    image: tispark:latest
+    build:
+      context: {{ .Values.tispark.buildPath | default "./tispark" }}
+      dockerfile: {{ .Values.tispark.dockerfile | default "Dockerfile" }}
+    {{- end }}
+    command:
+      - /opt/spark/sbin/start-master.sh
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_MASTER_PORT: {{ .Values.tispark.masterPort }}
+      SPARK_MASTER_WEBUI_PORT: {{ .Values.tispark.webuiPort }}
+    ports:
+      - "{{ .Values.tispark.masterPort }}:7077"
+      - "{{ .Values.tispark.webuiPort }}:8080"
+    depends_on:
+      {{- range until $tikvSize }}
+      - "tikv{{.}}"
+      {{- end }}
+    restart: on-failure
+  {{- range until $tisparkWorkerCount }}
+  tispark-slave{{ . }}:
+    {{- if $.Values.tispark.image }}
+    image: {{ $.Values.tispark.image }}
+    {{- else }}
+    image: tispark:latest
+    build:
+      context: {{ $.Values.tispark.buildPath | default "./tispark" }}
+      dockerfile: {{ $.Values.tispark.dockerfile | default "Dockerfile" }}
+    {{- end }}
+    command:
+      - /opt/spark/sbin/start-slave.sh
+      - spark://tispark-master:7077
+    environment:
+      SPARK_WORKER_WEBUI_PORT: {{ add $.Values.tispark.workerWebUIPort . }}
+    ports:
+      - "{{ add $.Values.tispark.workerWebUIPort . }}:{{ add $.Values.tispark.workerWebUIPort . }}"
+    depends_on:
+      - tispark-master
+    restart: on-failure
+  {{- end }}
+{{ end }}
+
 {{- if .Values.tidbVision }}
   tidb-vision:
     {{- if .Values.tidbVision.image }}
@@ -129,9 +178,7 @@ services:
       dockerfile: {{ .Values.tidbVision.dockerfile | default "Dockerfile" }}
     {{- end }}
     environment:
-      # TODO: we use only one pd endpoint
-      # because tidb-vision doesn't support multiple pd endpoint now
-      PD_ENDPOINT: pd0:2379
+      PD_ENDPOINT: {{ range until $pdSize }}pd{{.}}:2379 {{ end }}
     ports:
       {{- if .Values.tidbVision.port }}
       - "{{ .Values.tidbVision.port }}:8010"

--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -157,6 +157,8 @@ services:
     command:
       - /opt/spark/sbin/start-slave.sh
       - spark://tispark-master:7077
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
     environment:
       SPARK_WORKER_WEBUI_PORT: {{ add $.Values.tispark.workerWebUIPort . }}
     ports:

--- a/compose/values.yaml
+++ b/compose/values.yaml
@@ -2,7 +2,7 @@ data_dir: ./data
 
 pd:
   size: 3
-  image: pingcap/pd:latest
+  image: uhub.ucloud.cn/pingcap/pd:latest
 
   # If you want to build pd image from source, leave image empty and specify pd source directory
   # and its dockerfile name
@@ -11,7 +11,7 @@ pd:
 
 tikv:
   size: 3
-  image: pingcap/tikv:latest
+  image: uhub.ucloud.cn/pingcap/tikv:latest
 
   # If you want to build tikv image from source, leave image empty and specify tikv source directory
   # and its dockerfile name
@@ -19,7 +19,7 @@ tikv:
   # dockerfile: Dockerfile
 
 tidb:
-  image: pingcap/tidb:latest
+  image: uhub.ucloud.cn/pingcap/tidb:latest
 
   # If you want to build tidb image from source, leave image empty and specify tidb source directory
   # and its dockerfile name
@@ -28,9 +28,25 @@ tidb:
   mysqlPort: "4000"
   statusPort: "10080"
 
+tispark:
+  image: pingcap/tispark:latest
+
+  # If you want to build tidb image from source, leave image empty and specify tidb source directory
+  # and its dockerfile name
+  # buildPath: ./tidb
+  # dockerfile: Dockerfile
+  buildPath: ./tispark
+  dockerfile: Dockerfile
+
+  masterPort: 7077
+  webuiPort: 8080
+  workerCount: 1
+  # slave web ui port will be workerWebUIPort ~ workerWebUIPort+workerCount-1
+  workerWebUIPort: 38081
+
 # comment this out to disable tidb-vision
 tidbVision:
-  image: pingcap/tidb-vision:latest
+  image: uhub.ucloud.cn/pingcap/tidb-vision:latest
 
   # If you want to build tidb-vision image from source, leave image empty and specify tidb-vision source directory
   # and its dockerfile name
@@ -39,17 +55,17 @@ tidbVision:
   port: "8010"
 
 grafana:
-  image: grafana/grafana:4.6.3
+  image: uhub.ucloud.cn/pingcap/grafana:4.6.3
   port: "3000"
 
 pushgateway:
-  image: prom/pushgateway:v0.3.1
+  image: uhub.ucloud.cn/pingcap/pushgateway:v0.3.1
 
 prometheus:
-  image: prom/prometheus:v2.0.0
+  image: uhub.ucloud.cn/pingcap/prometheus:v2.0.0
   port: "9090"
 
 # This is used to import tidb monitor dashboard templates to grafana
 # this container runs only once and keep running until templates imported successfully
 dashboardInstaller:
-  image: pingcap/tidb-dashboard-installer:v1.0.0
+  image: uhub.ucloud.cn/pingcap/tidb-dashboard-installer:v1.0.0

--- a/config/spark-defaults.conf
+++ b/config/spark-defaults.conf
@@ -1,0 +1,1 @@
+spark.tispark.pd.addresses pd0:2379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,8 @@ services:
     command:
       - /opt/spark/sbin/start-slave.sh
       - spark://tispark-master:7077
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
     environment:
       SPARK_WORKER_WEBUI_PORT: 38081
     ports:
@@ -150,7 +152,7 @@ services:
   tidb-vision:
     image: uhub.ucloud.cn/pingcap/tidb-vision:latest
     environment:
-      PD_ENDPOINT: pd0:2379 pd1:2379 pd2:2379 
+      PD_ENDPOINT: pd0:2379 pd1:2379 pd2:2379
     ports:
       - "8010:8010"
 
@@ -186,4 +188,3 @@ services:
       - ./config/tidb-dashboard.json:/tidb.json:ro
       - ./config/overview-dashboard.json:/overview.json:ro
     restart: on-failure
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   pd0:
-    image: pingcap/pd:latest
+    image: uhub.ucloud.cn/pingcap/pd:latest
     ports:
       - "2379"
     volumes:
@@ -19,7 +19,7 @@ services:
       - --config=/pd.toml
     restart: on-failure
   pd1:
-    image: pingcap/pd:latest
+    image: uhub.ucloud.cn/pingcap/pd:latest
     ports:
       - "2379"
     volumes:
@@ -36,7 +36,7 @@ services:
       - --config=/pd.toml
     restart: on-failure
   pd2:
-    image: pingcap/pd:latest
+    image: uhub.ucloud.cn/pingcap/pd:latest
     ports:
       - "2379"
     volumes:
@@ -52,9 +52,8 @@ services:
       - --data-dir=/data/pd2
       - --config=/pd.toml
     restart: on-failure
-
   tikv0:
-    image: pingcap/tikv:latest
+    image: uhub.ucloud.cn/pingcap/tikv:latest
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data:/data
@@ -70,7 +69,7 @@ services:
       - "pd2"
     restart: on-failure
   tikv1:
-    image: pingcap/tikv:latest
+    image: uhub.ucloud.cn/pingcap/tikv:latest
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data:/data
@@ -86,7 +85,7 @@ services:
       - "pd2"
     restart: on-failure
   tikv2:
-    image: pingcap/tikv:latest
+    image: uhub.ucloud.cn/pingcap/tikv:latest
     volumes:
       - ./config/tikv.toml:/tikv.toml:ro
       - ./data:/data
@@ -103,7 +102,7 @@ services:
     restart: on-failure
 
   tidb:
-    image: pingcap/tidb:latest
+    image: uhub.ucloud.cn/pingcap/tidb:latest
     ports:
       - "4000:4000"
       - "10080:10080"
@@ -118,21 +117,50 @@ services:
       - "tikv1"
       - "tikv2"
     restart: on-failure
+  tispark-master:
+    image: pingcap/tispark:latest
+    command:
+      - /opt/spark/sbin/start-master.sh
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_MASTER_PORT: 7077
+      SPARK_MASTER_WEBUI_PORT: 8080
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+    depends_on:
+      - "tikv0"
+      - "tikv1"
+      - "tikv2"
+    restart: on-failure
+  tispark-slave0:
+    image: pingcap/tispark:latest
+    command:
+      - /opt/spark/sbin/start-slave.sh
+      - spark://tispark-master:7077
+    environment:
+      SPARK_WORKER_WEBUI_PORT: 38081
+    ports:
+      - "38081:38081"
+    depends_on:
+      - tispark-master
+    restart: on-failure
 
   tidb-vision:
-    image: pingcap/tidb-vision:latest
+    image: uhub.ucloud.cn/pingcap/tidb-vision:latest
     environment:
-      PD_ENDPOINT: pd0:2379 pd1:2379 pd2:2379
+      PD_ENDPOINT: pd0:2379 pd1:2379 pd2:2379 
     ports:
       - "8010:8010"
 
   # monitors
   pushgateway:
-    image: prom/pushgateway:v0.3.1
+    image: uhub.ucloud.cn/pingcap/pushgateway:v0.3.1
     restart: on-failure
   prometheus:
     user: root
-    image: prom/prometheus:v2.0.0
+    image: uhub.ucloud.cn/pingcap/prometheus:v2.0.0
     command:
       - --storage.tsdb.path=/data/prometheus
       - --config.file=/etc/prometheus/prometheus.yml
@@ -144,12 +172,12 @@ services:
       - ./data:/data
     restart: on-failure
   grafana:
-    image: grafana/grafana:4.6.3
+    image: uhub.ucloud.cn/pingcap/grafana:4.6.3
     ports:
       - "3000:3000"
     restart: on-failure
   dashboard-installer:
-    image: pingcap/tidb-dashboard-installer:v1.0.0
+    image: uhub.ucloud.cn/pingcap/tidb-dashboard-installer:v1.0.0
     command: ["grafana:3000"]
     volumes:
       - ./config/grafana-datasource.json:/datasource.json:ro
@@ -158,3 +186,4 @@ services:
       - ./config/tidb-dashboard.json:/tidb.json:ro
       - ./config/overview-dashboard.json:/overview.json:ro
     restart: on-failure
+

--- a/tispark/Dockerfile
+++ b/tispark/Dockerfile
@@ -1,0 +1,25 @@
+FROM anapsix/alpine-java:8
+
+ENV SPARK_VERSION=2.1.1 \
+    HADOOP_VERSION=2.7 \
+    TISPARK_VERSION=0.1.0-SNAPSHOT \
+    SPARK_HOME=/opt/spark \
+    SPARK_NO_DAEMONIZE=true \
+    SPARK_MASTER_PORT=7077 \
+    SPARK_MASTER_HOST=0.0.0.0 \
+    SPARK_MASTER_WEBUI_PORT=8080
+
+# base image only contains busybox version nohup and ps
+# spark scripts needs nohup in coreutils and ps in procps
+# and we can use mysql-client to test tidb connection
+RUN apk --no-cache add coreutils procps mysql-client
+
+RUN wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
+    && tar zxf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz -C /opt/ \
+    && ln -s /opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} ${SPARK_HOME} \
+    && wget -q http://download.pingcap.org/tispark-${TISPARK_VERSION}-jar-with-dependencies.jar -P ${SPARK_HOME}/jars \
+    && wget -q http://download.pingcap.org/tispark-sample-data.tar.gz \
+    && tar zxf tispark-sample-data.tar.gz -C ${SPARK_HOME}/data/ \
+    && rm -rf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz tispark-sample-data.tar.gz
+
+WORKDIR ${SPARK_HOME}


### PR DESCRIPTION
This PR closes #9, it adds TiSpark service in docker-compose and its Dockerfile. PTAL @zhexuany @c4pt0r 

*Note*: I've changed docker images from DockerHub to UCloud docker registry to make docker-compose easier up and running in China. @zhexuany You can test it if TiSpark works as expected. If it's ok, I'll change it back to DockerHub before this PR is merged