### PR TITLE
set tikv default max-open-files to 1024 to avoid quick start error

### DIFF
--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -210,7 +210,7 @@ address = "pushgateway:9091"
 # If max-open-files = -1, RocksDB will prefetch index and filter blocks into
 # block cache at startup, so if your database has a large working set, it will
 # take several minutes to open the db.
-# max-open-files = 40960
+max-open-files = 1024
 
 # Max size of rocksdb's MANIFEST file.
 # For detailed explanation please refer to https://github.com/facebook/rocksdb/wiki/MANIFEST
@@ -418,7 +418,7 @@ address = "pushgateway:9091"
 
 [raftdb]
 # max-sub-compactions = 1
-# max-open-files = 40960
+max-open-files = 1024
 # max-manifest-file-size = "20MB"
 # create-if-missing = true
 


### PR DESCRIPTION
The default max-open-files arguments are reset in #34, if users doesn't set ulimit correctly, TiKV would fail to start as reported by @RavenZZ in #37. This PR should fix it.