### PR TITLE
Fix a few grafana issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ $ docker-compose up -d
 $ mysql -h 127.0.0.1 -P 4000 -u root
 ```
 
-* Access monitor at http://localhost:3000
-
-Default user/password: admin/admin
+* Access monitor at http://localhost:3000 (login with admin/admin if you want to modify grafana)
 
 * Access [tidb-vision](https://github.com/pingcap/tidb-vision) at http://localhost:8010
 

--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -244,6 +244,7 @@ services:
   {{- if .Values.grafana }}
   grafana:
     image: {{ .Values.grafana.image }}
+    user: "0"
     {{- if eq .Values.networkMode "host" }}
     network_mode: host
     environment:
@@ -259,7 +260,8 @@ services:
     {{- end }}
     volumes:
       - ./config/grafana:/etc/grafana
-      - ./config/dashboards:/var/lib/grafana/dashboards
+      - ./config/dashboards:/tmp/dashboards
+      - ./data/grafana:/var/lib/grafana
     restart: on-failure
   dashboard-installer:
     {{- if .Values.dashboardInstaller.image }}

--- a/config/grafana/grafana.ini
+++ b/config/grafana/grafana.ini
@@ -249,7 +249,7 @@ signout_redirect_url =
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
-enabled = false
+enabled = true
 
 # specify organization name that should be used for unauthenticated users
 org_name = Main Org.

--- a/config/grafana/provisioning/dashboards/dashboards.yaml
+++ b/config/grafana/provisioning/dashboards/dashboards.yaml
@@ -7,4 +7,4 @@ providers:
   folder: ''
   type: file
   options:
-    path: /var/lib/grafana/dashboards
+    path: /tmp/dashboards

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,13 +195,15 @@ services:
     restart: on-failure
   grafana:
     image: grafana/grafana:6.0.1
+    user: "0"
     environment:
       GF_LOG_LEVEL: error
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
       GF_PATHS_CONFIG: /etc/grafana/grafana.ini
     volumes:
       - ./config/grafana:/etc/grafana
-      - ./config/dashboards:/var/lib/grafana/dashboards
+      - ./config/dashboards:/tmp/dashboards
+      - ./data/grafana:/var/lib/grafana
     ports:
       - "3000:3000"
     restart: on-failure


### PR DESCRIPTION
- Enable anonymous auth, then the user can access dashboards without login
- Store grafana data at `data/grafana` to persist grafana across reboots, if the user wants a fresh instance, they can erase data directories like other components (e.g. tidb, tikv)

Fixes https://github.com/pingcap/tidb-docker-compose/issues/58