### PR TITLE
separate condition statement

### DIFF
--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -101,7 +101,8 @@ services:
     restart: on-failure
   {{ end }}
 
-  {{- if and .Values.tidb .Values.tidb.enableBinlog }}
+  {{- if .Values.tidb }}
+  {{- if .Values.tidb.enableBinlog }}
   {{- range until $pumpSize }}
   pump{{ . }}:
     {{- if $.Values.pump.image }}
@@ -229,6 +230,7 @@ services:
       - "zoo{{ . }}"
       {{- end }}
     restart: on-failure
+  {{- end }}
   {{- end }}
   {{- end }}
   {{ end }}


### PR DESCRIPTION
## what does this do

To avoid nil pointer reference, separate condition of if statement. This will prevent the error when we generate compose file for TiKV.

## what is happened

I want to try to generate a compose file for TiKV. TiKV document says below.

> Edit the compose/values.yaml file to configure the networkMode and host and comment the tidb section out.

https://tikv.org/docs/tasks/quickstart/

However, I got nil pointer exception when I commented out tidb section.

```
$ helm template compose
Error: render error in "tidb-docker-compose/templates/docker-compose.yml": template: tidb-docker-compose/templates/docker-compose.yml:104:33: executing "tidb-docker-compose/templates/docker-compose.yml" at <.Values.tidb.enableBinlog>: nil pointer evaluating interface {}.enableBinlog
```

This error is occurred by evaluating `.Values.tidb` and `.Values.tidb.enableBinlog` together. This is why I separate this condition statement.