### PR TITLE
update tispark from 2.2 to 2.3

### DIFF
--- a/tispark/Dockerfile
+++ b/tispark/Dockerfile
@@ -2,7 +2,6 @@ FROM anapsix/alpine-java:8
 
 ENV SPARK_VERSION=2.3.3 \
     HADOOP_VERSION=2.7 \
-    TISPARK_VERSION=2.2.0-SNAPSHOT \
     TISPARK_R_VERSION=1.1 \
     TISPARK_PYTHON_VERSION=2.0 \
     SPARK_HOME=/opt/spark \
@@ -31,7 +30,7 @@ RUN wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-$
     && cp /opt/tispark-tests/tests/session.py ${SPARK_HOME}/python/pyspark/sql/ \
 	&& wget -q http://download.pingcap.org/tispark-assembly-latest-linux-amd64.tar.gz \
 	&& tar zxf ./tispark-assembly-latest-linux-amd64.tar.gz -C /opt/ \
-	&& cp /opt/assembly/target/tispark-assembly-${TISPARK_VERSION}.jar ${SPARK_HOME}/jars \
+	&& cp /opt/assembly/target/tispark-assembly-*.jar ${SPARK_HOME}/jars \
     && wget -q http://download.pingcap.org/tispark-sample-data.tar.gz \
     && tar zxf tispark-sample-data.tar.gz -C ${SPARK_HOME}/data/ \
     && rm -rf /opt/assembly/ spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz tispark-latest-linux-amd64.tar.gz tispark-sample-data.tar.gz


### PR DESCRIPTION
update tispark from 2.2 to 2.3

because of this PR: https://github.com/pingcap/tispark/pull/947