### PR TITLE
Add a "DO NOT USE IN PRODUCTION" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/pingcap/tidb-docker-compose.svg?branch=master)](https://travis-ci.org/pingcap/tidb-docker-compose)
 
+**WARNING: This is for testing only, DO NOT USE IN PRODUCTION!**
+
 ## Requirements
 
 * Docker >= 17.03


### PR DESCRIPTION
This repo is not ready for production. We should warn the user not to use this repo in production.