### PR TITLE
remove useless drainerPort from docker-compose.yml

### DIFF
--- a/compose/templates/docker-compose.yml
+++ b/compose/templates/docker-compose.yml
@@ -5,7 +5,6 @@
 {{- $tikvPort := .Values.tikv.port | int -}}
 {{- $pumpSize := .Values.pump.size | int }}
 {{- $pumpPort := .Values.pump.port | int }}
-{{- $drainerPort := .Values.drainer.port | int }}
 {{- $zooSize := .Values.zookeeper.size | int }}
 {{- $zooPort := .Values.zookeeper.port | int }}
 {{- $kafkaSize := .Values.kafka.size | int }}


### PR DESCRIPTION
drainerPort was added in #65 but was not used and will cause failure during render:
helm template -f values.yaml compose > generated-docker-compose.yml
Error: render error in "tidb-docker-compose/templates/docker-compose.yml": template: tidb-docker-compose/templates/docker-compose.yml:8:44: executing "tidb-docker-compose/templates/docker-compose.yml" at <int>: wrong number of args for int: want 1 got 0