### PR TITLE
fix docker swarm pd wrong command argument

### DIFF
--- a/docker-swarm.yml
+++ b/docker-swarm.yml
@@ -24,7 +24,6 @@ services:
       - --data-dir=/data/pd0
       - --config=/pd.toml
       - --log-file=/logs/pd0.log
-      - --log-level=info
   pd1:
     image: pingcap/pd:latest
     ports:


### PR DESCRIPTION
PD does not have `log-level` command line argument. This PR fix the wrong argument of pd-0 in docker swarm.