### PR TITLE
Add support for DM

### DIFF
--- a/config/dm-master.toml
+++ b/config/dm-master.toml
@@ -1,0 +1,43 @@
+# Master Configuration.
+
+# log configuration
+#log-level = "info"
+#log-file = "dm-master.log"
+
+# dm-master listen address
+master-addr = ":8261"
+
+# addr(i.e. 'host:port') to advertise to the public
+advertise-addr = "127.0.0.1:8261"
+
+# human-readable name for this DM-master member
+name = "dm-master"
+
+# path to the data directory (default 'default.${name}')
+data-dir = "default.dm-master"
+
+# URLs for peer traffic
+peer-urls = "http://127.0.0.1:8291"
+
+# advertise URLs for peer traffic (default '${peer-urls}')
+advertise-peer-urls = "http://127.0.0.1:8291"
+
+# initial cluster configuration for bootstrapping, e.g. dm-master=http://127.0.0.1:8291
+initial-cluster = "dm-master=http://127.0.0.1:8291"
+
+# Join to an existing DM-master cluster, a string of existing cluster's endpoints.
+join = ""
+
+# rpc configuration
+#
+# rpc timeout is a positive number plus time unit. we use golang standard time
+# units including: "ns", "us", "ms", "s", "m", "h". You should provide a proper
+# rpc timeout according to your use scenario.
+rpc-timeout = "30s"
+# rpc limiter controls how frequently events are allowed to happen.
+# It implements a "token bucket" of size `rpc-rate-limit`, initially full and
+# refilled at rate `rpc-rate-limit` tokens per second. Note `rpc-rate-limit`
+# is float64 type, so remember to add a decimal point and one trailing 0 if its
+# literal value happens to be an integer.
+rpc-rate-limit = 10.0
+rpc-rate-burst = 40

--- a/config/dm-worker.toml
+++ b/config/dm-worker.toml
@@ -1,0 +1,10 @@
+# Worker Configuration.
+
+#log configuration
+#log-level = "info"
+#log-file = "dm-worker.log"
+
+#dm-worker listen address
+worker-addr = ":8262"
+advertise-addr = "127.0.0.1:8262"
+join = "127.0.0.1:8261"

--- a/docker-compose-dm.yml
+++ b/docker-compose-dm.yml
@@ -1,0 +1,232 @@
+version: '2.1'
+
+services:
+  pd0:
+    image: pingcap/pd:latest
+    ports:
+      - "2379"
+    volumes:
+      - ./config/pd.toml:/pd.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --name=pd0
+      - --client-urls=http://0.0.0.0:2379
+      - --peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://pd0:2379
+      - --advertise-peer-urls=http://pd0:2380
+      - --initial-cluster=pd0=http://pd0:2380,pd1=http://pd1:2380,pd2=http://pd2:2380
+      - --data-dir=/data/pd0
+      - --config=/pd.toml
+      - --log-file=/logs/pd0.log
+    restart: on-failure
+  pd1:
+    image: pingcap/pd:latest
+    ports:
+      - "2379"
+    volumes:
+      - ./config/pd.toml:/pd.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --name=pd1
+      - --client-urls=http://0.0.0.0:2379
+      - --peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://pd1:2379
+      - --advertise-peer-urls=http://pd1:2380
+      - --initial-cluster=pd0=http://pd0:2380,pd1=http://pd1:2380,pd2=http://pd2:2380
+      - --data-dir=/data/pd1
+      - --config=/pd.toml
+      - --log-file=/logs/pd1.log
+    restart: on-failure
+  pd2:
+    image: pingcap/pd:latest
+    ports:
+      - "2379"
+    volumes:
+      - ./config/pd.toml:/pd.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --name=pd2
+      - --client-urls=http://0.0.0.0:2379
+      - --peer-urls=http://0.0.0.0:2380
+      - --advertise-client-urls=http://pd2:2379
+      - --advertise-peer-urls=http://pd2:2380
+      - --initial-cluster=pd0=http://pd0:2380,pd1=http://pd1:2380,pd2=http://pd2:2380
+      - --data-dir=/data/pd2
+      - --config=/pd.toml
+      - --log-file=/logs/pd2.log
+    restart: on-failure
+  tikv0:
+    image: pingcap/tikv:latest
+    volumes:
+      - ./config/tikv.toml:/tikv.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --addr=0.0.0.0:20160
+      - --advertise-addr=tikv0:20160
+      - --data-dir=/data/tikv0
+      - --pd=pd0:2379,pd1:2379,pd2:2379
+      - --config=/tikv.toml
+      - --log-file=/logs/tikv0.log
+    depends_on:
+      - "pd0"
+      - "pd1"
+      - "pd2"
+    restart: on-failure
+  tikv1:
+    image: pingcap/tikv:latest
+    volumes:
+      - ./config/tikv.toml:/tikv.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --addr=0.0.0.0:20160
+      - --advertise-addr=tikv1:20160
+      - --data-dir=/data/tikv1
+      - --pd=pd0:2379,pd1:2379,pd2:2379
+      - --config=/tikv.toml
+      - --log-file=/logs/tikv1.log
+    depends_on:
+      - "pd0"
+      - "pd1"
+      - "pd2"
+    restart: on-failure
+  tikv2:
+    image: pingcap/tikv:latest
+    volumes:
+      - ./config/tikv.toml:/tikv.toml:ro
+      - ./data:/data
+      - ./logs:/logs
+    command:
+      - --addr=0.0.0.0:20160
+      - --advertise-addr=tikv2:20160
+      - --data-dir=/data/tikv2
+      - --pd=pd0:2379,pd1:2379,pd2:2379
+      - --config=/tikv.toml
+      - --log-file=/logs/tikv2.log
+    depends_on:
+      - "pd0"
+      - "pd1"
+      - "pd2"
+    restart: on-failure
+
+  tidb:
+    image: pingcap/tidb:latest
+    ports:
+      - "4000:4000"
+      - "10080:10080"
+    volumes:
+      - ./config/tidb.toml:/tidb.toml:ro
+      - ./logs:/logs
+    command:
+      - --store=tikv
+      - --path=pd0:2379,pd1:2379,pd2:2379
+      - --config=/tidb.toml
+      - --log-file=/logs/tidb.log
+      - --advertise-address=tidb
+    depends_on:
+      - "tikv0"
+      - "tikv1"
+      - "tikv2"
+    restart: on-failure
+
+  dm-master:
+    image: pingcap/dm:latest
+    volumes:
+      - ./config/dm-master.toml:/dm-master.toml:ro
+      - ./logs:/logs
+    command:
+      - /dm-master
+      - --log-file=/logs/dm-master.log
+      - --config=/dm-master.toml
+    restart: on-failure
+  dm-worker0:
+    image: pingcap/dm:latest
+    volumes:
+      - ./config/dm-worker.toml:/dm-worker.toml:ro
+      - ./logs:/logs
+    command:
+      - /dm-worker
+      - --log-file=/logs/dm-worker0.log
+      - --config=/dm-worker.toml
+    restart: on-failure
+
+  tispark-master:
+    image: pingcap/tispark:latest
+    command:
+      - /opt/spark/sbin/start-master.sh
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_MASTER_PORT: 7077
+      SPARK_MASTER_WEBUI_PORT: 8080
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+    depends_on:
+      - "tikv0"
+      - "tikv1"
+      - "tikv2"
+    restart: on-failure
+  tispark-slave0:
+    image: pingcap/tispark:latest
+    command:
+      - /opt/spark/sbin/start-slave.sh
+      - spark://tispark-master:7077
+    volumes:
+      - ./config/spark-defaults.conf:/opt/spark/conf/spark-defaults.conf:ro
+    environment:
+      SPARK_WORKER_WEBUI_PORT: 38081
+    ports:
+      - "38081:38081"
+    depends_on:
+      - tispark-master
+    restart: on-failure
+
+  tidb-vision:
+    image: pingcap/tidb-vision:latest
+    environment:
+      PD_ENDPOINT: pd0:2379
+    ports:
+      - "8010:8010"
+    restart: on-failure
+
+  # monitors
+  pushgateway:
+    image: prom/pushgateway:v0.3.1
+    command:
+      - --log.level=error
+    restart: on-failure
+  prometheus:
+    user: root
+    image: prom/prometheus:v2.2.1
+    command:
+      - --log.level=error
+      - --storage.tsdb.path=/data/prometheus
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./config/pd.rules.yml:/etc/prometheus/pd.rules.yml:ro
+      - ./config/tikv.rules.yml:/etc/prometheus/tikv.rules.yml:ro
+      - ./config/tidb.rules.yml:/etc/prometheus/tidb.rules.yml:ro
+      - ./data:/data
+    restart: on-failure
+  grafana:
+    image: grafana/grafana:6.0.1
+    user: "0"
+    environment:
+      GF_LOG_LEVEL: error
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+      GF_PATHS_CONFIG: /etc/grafana/grafana.ini
+    volumes:
+      - ./config/grafana:/etc/grafana
+      - ./config/dashboards:/tmp/dashboards
+      - ./data/grafana:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    restart: on-failure


### PR DESCRIPTION
Closes: #97

I added the two template config files with the logging commented out and copied one of the compose files and added this:
```
  dm-master:
    image: pingcap/dm:latest
    volumes:
      - ./config/dm-master.toml:/dm-master.toml:ro
      - ./logs:/logs
    command:
      - /dm-master
      - --log-file=/logs/dm-master.log
      - --config=/dm-master.toml
    restart: on-failure
  dm-worker0:
    image: pingcap/dm:latest
    volumes:
      - ./config/dm-worker.toml:/dm-worker.toml:ro
      - ./logs:/logs
    command:
      - /dm-worker
      - --log-file=/logs/dm-worker0.log
      - --config=/dm-worker.toml
    restart: on-failure
```
Not sure what else is needed to get this to properly support DM