### PR TITLE
README: suggest disabling selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@
 * Docker Compose >= 1.6.0
 
 > **Note:** [Legacy Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_mac/) users must migrate to [Docker for Mac](https://store.docker.com/editions/community/docker-ce-desktop-mac), since it is tested that tidb-docker-compose cannot be started on Docker Toolbox and Docker Machine.
+> **Note:** It is recommended to disable SELinux.
 
 ## Quick start
 
 ```bash
 $ git clone https://github.com/pingcap/tidb-docker-compose.git
 $ cd tidb-docker-compose && docker-compose pull # Get the latest Docker images
+$ sudo setenforce 0
 $ docker-compose up -d
 $ mysql -h 127.0.0.1 -P 4000 -u root
 ```


### PR DESCRIPTION
Without disabling SELinux the containers can't read the volumes. It might be possible to change the SELinux configuration and/or file labels but it is advised to disable SELinux for now.

This was tested on CentOS 7.9.2009 with Docker compose v1.29.2 and Docker 1.13.1