### PR TITLE
fix:update tispark in docker-compose

### DIFF
--- a/docker-compose-binlog.yml
+++ b/docker-compose-binlog.yml
@@ -372,7 +372,7 @@ services:
     restart: on-failure
   
   tispark-master:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-master.sh
     volumes:
@@ -389,7 +389,7 @@ services:
       - "tikv2"
     restart: on-failure
   tispark-slave0:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-slave.sh
       - spark://tispark-master:7077

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - "tikv2"
     restart: on-failure
   tispark-master:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-master.sh
     volumes:
@@ -150,7 +150,7 @@ services:
       - "tikv2"
     restart: on-failure
   tispark-slave0:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-slave.sh
       - spark://tispark-master:7077

--- a/docker-swarm.yml
+++ b/docker-swarm.yml
@@ -100,7 +100,7 @@ services:
         replicas: 1
 
   tispark-master:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-master.sh
     volumes:
@@ -116,7 +116,7 @@ services:
     deploy:
         replicas: 1
   tispark-slave:
-    image: pingcap/tispark:latest
+    image: pingcap/tispark:v2.1.1
     command:
       - /opt/spark/sbin/start-slave.sh
       - spark://tispark-master:7077


### PR DESCRIPTION
according to https://github.com/pingcap/tidb-docker-compose/issues/106, the image `pingcap/tispark:latest` can't be downloaded, so fix it to `pingcap/tispark:v2.1.1`.
In fact, we would like to lead user to use `tiup` rather than docker-compose which is almost deprecated