### PR TITLE
Use `log.level` instead of `log-level`

### DIFF
--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -6,7 +6,7 @@
 #    e.g.: 78_000 = "1.3m"
 
 # log level: trace, debug, info, warn, error, off.
-log-level = "error"
+log.level = "error"
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 

--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -9,7 +9,8 @@
 [log]
 level = "error"
 # file to store log, write to stderr if it's empty.
-# log-file = ""
+[log.file]
+# filename = ""
 
 [readpool.storage]
 # size of thread pool for high-priority operations

--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -6,7 +6,8 @@
 #    e.g.: 78_000 = "1.3m"
 
 # log level: trace, debug, info, warn, error, off.
-log.level = "error"
+[log]
+level = "error"
 # file to store log, write to stderr if it's empty.
 # log-file = ""
 


### PR DESCRIPTION
This commit addresses these warning/error.
```
% docker-compose up
... snip ...
tikv0_1           | deprecated configuration, log-level has been moved to log.level
tikv0_1           | override log.level with log-level, Error
```

log.level is available for TiDB 5.4 which is resolved as the `latest` tag
 via https://github.com/tikv/tikv/pull/11808